### PR TITLE
Reference Google J2CL, a new Java to JS transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Notice: Consider J2CL #
+
+On Nov 22 2018, Google has released J2CL, a new Java to JavaScript transpiler. You should check it out at http://j2cl.io/
+
 # What is gwt-exporter? #
 The project is a GWT module which contains a generator capable of taking GWT classes and exporting them as ordinary Javascript APIs callable from hand-written Javascript, without having to deal with JSNI, and suitable for use in mashups.
 


### PR DESCRIPTION
Adds a reference to J2CL on the top of README. J2CL is a new Java to JavaScript transpiler released by Google on Nov 22 2018. See http://j2cl.io/

Although it was not stated that way by Google, it's clear to me that J2CL is a specialized tool to do what gwt-exporter does.